### PR TITLE
Fixed ModuleNotFoundError: No module named 'numba.decorators'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-torch==1.4.0
-numpy==1.17.4
 librosa==0.7.2
-scipy==1.4.1
-tensorboard==2.0
-soundfile==0.10.3.post1
 matplotlib==3.1.3
+numba==0.48
+numpy==1.17.4
+scipy==1.4.1
+soundfile==0.10.3.post1
+tensorboard==2.0
+torch==1.4.0


### PR DESCRIPTION
Hi,
  I got the following error message trying `python train.py --help`

```bash
Traceback (most recent call last):
  File "../train.py", line 16, in <module>
    from meldataset import MelDataset, mel_spectrogram, get_dataset_filelist
  File "/gpfs/fs1/nrc/ict/others/u/sam037/tts/hifi-gan.git/meldataset.py", line 7, in <module>
    from librosa.util import normalize
  File "/home/sam037/.conda/envs/hifi-gan-TTS/lib/python3.8/site-packages/librosa/__init__.py", line 12, in <module>
    from . import core
  File "/home/sam037/.conda/envs/hifi-gan-TTS/lib/python3.8/site-packages/librosa/core/__init__.py", line 125, in <module>
    from .time_frequency import *  # pylint: disable=wildcard-import
  File "/home/sam037/.conda/envs/hifi-gan-TTS/lib/python3.8/site-packages/librosa/core/time_frequency.py", line 11, in <module>
    from ..util.exceptions import ParameterError
  File "/home/sam037/.conda/envs/hifi-gan-TTS/lib/python3.8/site-packages/librosa/util/__init__.py", line 77, in <module>
    from .utils import *  # pylint: disable=wildcard-import
  File "/home/sam037/.conda/envs/hifi-gan-TTS/lib/python3.8/site-packages/librosa/util/utils.py", line 15, in <module>
    from .decorators import deprecated
  File "/home/sam037/.conda/envs/hifi-gan-TTS/lib/python3.8/site-packages/librosa/util/decorators.py", line 9, in <module>
    from numba.decorators import jit as optional_jit
ModuleNotFoundError: No module named 'numba.decorators'
```

A quick google search reveals that [numba removed the decorators module with version 0.50](https://github.com/librosa/librosa/issues/1160#issuecomment-643068317) and simply pinning the version to `numba==0.48` fixes the issue.


# Create a conda environment

```bash
conda create --name hifi-gan-TTS  python=3.8
conda activate hifi-gan-TTS
conda install --channel pytorch pytorch=1.4.0
pip install -r requirements.txt
```